### PR TITLE
Update cleanRun to fully remove a run's Analysis directory (if it exists)

### DIFF
--- a/check-and-clean/cleanRun
+++ b/check-and-clean/cleanRun
@@ -36,6 +36,7 @@ fi
 
 set -x
 mkdir -p ./sgeLog
+rm -rf Analysis
 rm -rf Images
 rm -rf ReadPrep1/Images
 rm -rf ReadPrep2/Images


### PR DESCRIPTION
Support to clean run directories with instrument onboard/DRAGEN analysis.

We expect that all analysis, stats, logs etc from this run directory be moved, copied or hard linked before the run directory is cleaned.