### PR TITLE
GP-5280 consider Cardea case-statuses when determining if a run can be cleaned

### DIFF
--- a/check-and-clean/cardea.py
+++ b/check-and-clean/cardea.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+import argparse
+import json
+import sys
+from urllib.request import urlopen
+
+DELETE = -1
+CLEAN = 0
+NO_CLEAN = 1
+NO_QCS = 2
+CONTINUE = 100
+
+
+def main(args):
+    run_case_statuses = get_sequencer_run_case_statuses(args.run, args.cardea_url, verbose=args.verbose)
+    decision = decisions(run_case_statuses, args.run, verbose=args.verbose)
+    return decision
+
+
+def get_sequencer_run_case_statuses(run, base_cardea_url, verbose=False):
+    url = "/".join([base_cardea_url, "case-statuses", run])
+    if verbose:
+        print(f"Cardea URL: {url}", file=sys.stderr)
+    return json.loads(urlopen(url).read().decode('utf-8'))
+
+
+def decisions(run_case_statuses, run, verbose=False):
+    if (run_case_statuses is None
+            or type(run_case_statuses) is not dict
+            or run_case_statuses.keys() != {'activeCases', 'completedCases', 'stoppedCases'}):
+        if verbose:
+            print(f"Cardea run case-statuses output:\n{run_case_statuses}", file=sys.stderr)
+        raise Exception("Unable to parse Cardea case statuses response")
+
+    active_case_count = len(run_case_statuses['activeCases']) + len(run_case_statuses['stoppedCases'])
+    completed_case_count = len(run_case_statuses['completedCases'])
+    total_case_count = active_case_count + completed_case_count
+
+    if total_case_count == 0:
+        if verbose:
+            print(f"No cases for {run} found in Cardea", file=sys.stderr)
+        return CONTINUE
+    if active_case_count == 0:
+        if verbose:
+            print(f"All {total_case_count} cases for {run} are complete in Cardea", file=sys.stderr)
+        return CLEAN
+    if active_case_count > 0:
+        if verbose:
+            print(f"{active_case_count} of {total_case_count} cases for {run} are active in Cardea", file=sys.stderr)
+        return NO_CLEAN
+
+    raise Exception("Unexpected state while determining Cardea case-statuses decision")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Searches for a sequencer run's case statuses in Cardea")
+    parser.add_argument("--run", "-r", help="the name of the sequencer run, e.g. 111130_h801_0064_AC043YACXX", required=True)
+    parser.add_argument("--cardea-url", help="The Cardea URL", default="https://cardea.gsi.oicr.on.ca")
+    parser.add_argument("--verbose", "-v", help="Verbose logging", action="store_true")
+    args = parser.parse_args()
+    sys.exit(main(args))

--- a/check-and-clean/checkRunBeforeClean.py
+++ b/check-and-clean/checkRunBeforeClean.py
@@ -1,7 +1,13 @@
 #!/usr/bin/python
-import pinery,fpr,jira,cardea
 import argparse
+import sys
 import time
+
+import cardea
+import fpr
+import jira
+import pinery
+
 
 def main(args):
     base_pinery_url = args.pinery_url
@@ -16,55 +22,54 @@ def main(args):
 
     if args.verbose:
         print(f"Cardea decision for {args.run} = {cardea_decision}", file=sys.stderr)
-        print(time.strftime("%d/%m/%Y %H:%M:%S"),args.run, file=sys.stderr)
+        print(time.strftime("%d/%m/%Y %H:%M:%S"), args.run, file=sys.stderr)
         print("------------------------\nCardea done\n------------------------", file=sys.stderr)
 
+    result = [args.run]
+    decision = "Clean"
+    pveto = False
 
-    result=[args.run]
-    decision="Clean"
-    pveto=False
-    
-    prun = pinery.get_pinery_obj(base_pinery_url+"/sequencerrun?name="+args.run)
-    
+    prun = pinery.get_pinery_obj(base_pinery_url + "/sequencerrun?name=" + args.run)
+
     presult = pinery.decisions(prun, base_pinery_url, verbose=args.verbose)
-    pskippedlanes=pinery.get_skipped_lanes(prun)
+    pskippedlanes = pinery.get_skipped_lanes(prun)
     if args.verbose:
-        print("------------------------\nPinery done\n------------------------", file=sys.stderr)  
+        print("------------------------\nPinery done\n------------------------", file=sys.stderr)
 
-    if presult==pinery.CLEAN:
+    if presult == pinery.CLEAN:
         result.append("Pinery: Failed or skipped run")
-        decision="Clean"
-        pveto=True
-    elif presult==pinery.DELETE:
+        decision = "Clean"
+        pveto = True
+    elif presult == pinery.DELETE:
         result.append("Pinery: Not in lims; Delete, add to GP-596")
-        decision="Delete"
-        pveto=True
-    elif presult==pinery.NO_CLEAN:
+        decision = "Delete"
+        pveto = True
+    elif presult == pinery.NO_CLEAN:
         result.append("Pinery: In progress run")
-        decision="No Clean"
-        pveto=True
-    elif presult==pinery.NO_QCS and cardea_decision==cardea.CLEAN:
+        decision = "No Clean"
+        pveto = True
+    elif presult == pinery.NO_QCS and cardea_decision == cardea.CLEAN:
         # special situation where we allow Cardea case statuses override Pinery signoff statuses
         if args.verbose:
             print(f"Warning: {args.run} Pinery signoffs are not complete, but Cardea case signoffs are - proceeding with cleaning", file=sys.stderr)
-        decision="Clean"
-    elif presult==pinery.NO_QCS and args.fpr is None:
+        decision = "Clean"
+    elif presult == pinery.NO_QCS and args.fpr is None:
         result.append("Pinery: Signoffs not complete")
-        decision="No Clean"
+        decision = "No Clean"
 
-    #Pinery overrules everything else. If it vetos continuing, no point in running expensive API queries
+    # Pinery overrules everything else. If it vetos continuing, no point in running expensive API queries
     if pveto:
         if args.verbose:
-            for k,v in list(pskippedlanes.items()):
-                if v==True:
-                    print("Lane ",k," is skipped:",v)
-            print("------------------------\n"+args.run+" FINAL \n------------------------", file=sys.stderr)
+            for k, v in list(pskippedlanes.items()):
+                if v == True:
+                    print("Lane ", k, " is skipped:", v)
+            print("------------------------\n" + args.run + " FINAL \n------------------------", file=sys.stderr)
             print("Pinery", str(presult), "\nJIRA Not run\nFPR Not run", file=sys.stderr)
-        result.insert(1,decision)
+        result.insert(1, decision)
         print("\t".join(result))
         return
-    
-    jveto=False
+
+    jveto = False
 
     if args.verbose:
         print("------------------------\nJIRA\n------------------------", file=sys.stderr)
@@ -74,49 +79,47 @@ def main(args):
     jruns = jruns_summary.copy()
     jruns.update(jruns_text)
 
-    jresult_summary = jira.decisions(jruns,verbose=args.verbose)
+    jresult_summary = jira.decisions(jruns, verbose=args.verbose)
 
-    if jresult_summary==jira.NO_CLEAN:
+    if jresult_summary == jira.NO_CLEAN:
         result.append("JIRA: Open tickets (by summary and text)")
-        jveto=True
-        decision="No Clean"
+        jveto = True
+        decision = "No Clean"
 
-    sresult="Disabled"
+    sresult = "Disabled"
     # searching the FPR does not happen unless it is provided
     if args.fpr is not None:
-        anfpr=args.fpr        
+        anfpr = args.fpr
 
         if args.verbose:
             print("------------------------\nFPR\n------------------------", file=sys.stderr)
-        sruns = fpr.get_sequencer_run(args.run,pskippedlanes,fpr=anfpr)
-        sresult = fpr.decisions(sruns,expected_lanes=pinery.get_positions(prun),verbose=args.verbose)
-        if sresult==fpr.NO_CLEAN:
+        sruns = fpr.get_sequencer_run(args.run, pskippedlanes, fpr=anfpr)
+        sresult = fpr.decisions(sruns, expected_lanes=pinery.get_positions(prun), verbose=args.verbose)
+        if sresult == fpr.NO_CLEAN:
             result.append("FPR:No Clean")
-            decision="No Clean"
-        elif sresult==fpr.CONTINUE:
+            decision = "No Clean"
+        elif sresult == fpr.CONTINUE:
             result.append("FPR: issues detected")
             if not jveto:
-                decision="Clean"
+                decision = "Clean"
     if args.verbose:
-        for k,v in list(pskippedlanes.items()):
-            if v==True:
-                print("Lane ",k," is skipped:",v,file=sys.stderr)
+        for k, v in list(pskippedlanes.items()):
+            if v == True:
+                print("Lane ", k, " is skipped:", v, file=sys.stderr)
 
-    print("------------------------\n"+args.run+" FINAL \n------------------------", file=sys.stderr)
+    print("------------------------\n" + args.run + " FINAL \n------------------------", file=sys.stderr)
     print("Pinery", str(presult), "\nJIRA summary", str(jresult_summary), "\nFPR", str(sresult), file=sys.stderr)
 
-
-    result.insert(1,decision)
+    result.insert(1, decision)
     print("\t".join(result))
 
 
 if __name__ == "__main__":
-    import sys
     parser = argparse.ArgumentParser(description="Checks a sequencer run to see if it can be cleaned")
     parser.add_argument("--run", "-r", help="the name of the sequencer run, e.g. 111130_h801_0064_AC043YACXX", required=True)
     parser.add_argument("--fpr", "-f", help="enable searching the FPR by providing path to the file provenance report. Increases time substantially and toggles off QC checking.")
-    parser.add_argument("--verbose","-v", help="Verbose logging",action="store_true")
+    parser.add_argument("--verbose", "-v", help="Verbose logging", action="store_true")
     parser.add_argument("--pinery-url", help="The Pinery URL", default="http://pinery.gsi.oicr.on.ca")
     parser.add_argument("--cardea-url", help="The Cardea URL", default="https://cardea.gsi.oicr.on.ca")
-    args=parser.parse_args()
+    args = parser.parse_args()
     main(args)

--- a/check-and-clean/checkRunBeforeClean.py
+++ b/check-and-clean/checkRunBeforeClean.py
@@ -3,7 +3,7 @@ import pinery,fpr,jira
 import argparse
 
 def main(args):
-    pineryurl="http://pinery.gsi.oicr.on.ca"
+    base_pinery_url = args.pinery_url
 
     if args.verbose:
         import time
@@ -15,9 +15,9 @@ def main(args):
     decision="Clean"
     pveto=False
     
-    prun = pinery.get_pinery_obj(pineryurl+"/sequencerrun?name="+args.run)
+    prun = pinery.get_pinery_obj(base_pinery_url+"/sequencerrun?name="+args.run)
     
-    presult = pinery.decisions(prun, verbose=args.verbose)
+    presult = pinery.decisions(prun, base_pinery_url, verbose=args.verbose)
     pskippedlanes=pinery.get_skipped_lanes(prun)
     if args.verbose:
         print("------------------------\nPinery done\n------------------------", file=sys.stderr)  
@@ -102,5 +102,6 @@ if __name__ == "__main__":
     parser.add_argument("--run", "-r", help="the name of the sequencer run, e.g. 111130_h801_0064_AC043YACXX", required=True)
     parser.add_argument("--fpr", "-f", help="enable searching the FPR by providing path to the file provenance report. Increases time substantially and toggles off QC checking.")
     parser.add_argument("--verbose","-v", help="Verbose logging",action="store_true")
+    parser.add_argument("--pinery-url", help="The pinery URL", default="http://pinery.gsi.oicr.on.ca")
     args=parser.parse_args()
     main(args)

--- a/check-and-clean/checkRunBeforeClean.py
+++ b/check-and-clean/checkRunBeforeClean.py
@@ -1,14 +1,23 @@
 #!/usr/bin/python
-import pinery,fpr,jira
+import pinery,fpr,jira,cardea
 import argparse
+import time
 
 def main(args):
     base_pinery_url = args.pinery_url
+    base_cardea_url = args.cardea_url
 
     if args.verbose:
-        import time
+        print(time.strftime("%d/%m/%Y %H:%M:%S"), args.run, file=sys.stderr)
+        print("------------------------\nCardea\n------------------------", file=sys.stderr)
+
+    cardea_sequencer_run_case_statuses = cardea.get_sequencer_run_case_statuses(args.run, base_cardea_url, verbose=args.verbose)
+    cardea_decision = cardea.decisions(cardea_sequencer_run_case_statuses, args.run, verbose=args.verbose)
+
+    if args.verbose:
+        print(f"Cardea decision for {args.run} = {cardea_decision}", file=sys.stderr)
         print(time.strftime("%d/%m/%Y %H:%M:%S"),args.run, file=sys.stderr)
-        print("------------------------\nPinery\n------------------------", file=sys.stderr)
+        print("------------------------\nCardea done\n------------------------", file=sys.stderr)
 
 
     result=[args.run]
@@ -34,6 +43,11 @@ def main(args):
         result.append("Pinery: In progress run")
         decision="No Clean"
         pveto=True
+    elif presult==pinery.NO_QCS and cardea_decision==cardea.CLEAN:
+        # special situation where we allow Cardea case statuses override Pinery signoff statuses
+        if args.verbose:
+            print(f"Warning: {args.run} Pinery signoffs are not complete, but Cardea case signoffs are - proceeding with cleaning", file=sys.stderr)
+        decision="Clean"
     elif presult==pinery.NO_QCS and args.fpr is None:
         result.append("Pinery: Signoffs not complete")
         decision="No Clean"
@@ -102,6 +116,7 @@ if __name__ == "__main__":
     parser.add_argument("--run", "-r", help="the name of the sequencer run, e.g. 111130_h801_0064_AC043YACXX", required=True)
     parser.add_argument("--fpr", "-f", help="enable searching the FPR by providing path to the file provenance report. Increases time substantially and toggles off QC checking.")
     parser.add_argument("--verbose","-v", help="Verbose logging",action="store_true")
-    parser.add_argument("--pinery-url", help="The pinery URL", default="http://pinery.gsi.oicr.on.ca")
+    parser.add_argument("--pinery-url", help="The Pinery URL", default="http://pinery.gsi.oicr.on.ca")
+    parser.add_argument("--cardea-url", help="The Cardea URL", default="https://cardea.gsi.oicr.on.ca")
     args=parser.parse_args()
     main(args)

--- a/check-and-clean/checkRunForPineryFPR.py
+++ b/check-and-clean/checkRunForPineryFPR.py
@@ -6,7 +6,7 @@ import argparse
 
 
 def main(args):
-    pineryurl = "http://pinery.gsi.oicr.on.ca"
+    base_pinery_url = args.pinery_url
     if args.verbose:
         import time
         print(time.strftime("%d/%m/%Y %H:%M:%S"),args.run, file=sys.stderr)
@@ -17,8 +17,8 @@ def main(args):
         print("If running in offline mode, supply a Pinery JSON file.")
         exit(1)
     else:
-        pruns = [pinery.get_pinery_obj(pineryurl+"/sequencerrun?name="+args.run)]
-    presult = pinery.decisions(pruns, verbose=args.verbose, offline=args.offline)
+        pruns = [pinery.get_pinery_obj(base_pinery_url+"/sequencerrun?name="+args.run)]
+    presult = pinery.decisions(pruns, base_pinery_url, verbose=args.verbose, offline=args.offline)
     if args.verbose:
         print("------------------------\nFPR\n------------------------", file=sys.stderr)
     if args.fpr:
@@ -67,5 +67,6 @@ if __name__ == "__main__":
     parser.add_argument("--pineryjson","-j", help="Location of the Pinery sequencerrun JSON file for offline mode")
     parser.add_argument("--offline","-o", help="Offline mode. Don't attempt to contact Pinery", action="store_true")
     parser.add_argument("--fpr","-f", help="Alternative file provenance report, TSV format with header, zipped.")
+    parser.add_argument("--pinery-url", help="The pinery URL", default="http://pinery.gsi.oicr.on.ca")
     args=parser.parse_args()
     main(args)

--- a/check-and-clean/pinery.py
+++ b/check-and-clean/pinery.py
@@ -5,8 +5,6 @@ import argparse
 import re
 import urllib.request, urllib.error, urllib.parse,ssl
 
-oicrurl="http://pinery.gsi.oicr.on.ca"
-
 DELETE=-1
 CLEAN=0
 NO_CLEAN=1
@@ -14,14 +12,12 @@ NO_QCS=2
 CONTINUE=100
 
 def main(args):
-    url=oicrurl
-    if args.url is not None:
-        url=args.url
+    base_pinery_url = args.pinery_url
     if args.json is None and not args.offline:
-        runs = get_sequencer_runs(args.run,url=url)
+        runs = get_sequencer_runs(args.run, base_pinery_url=base_pinery_url)
     else:
         runs = open_json(args.json,args.run)
-    all_decisions = [decisions(run,verbose=args.verbose,offline=args.offline) for run in runs]
+    all_decisions = [decisions(run,base_pinery_url,verbose=args.verbose,offline=args.offline) for run in runs]
     return max(all_decisions)
 
 def get_sequencer_run(runs_obj, rname):
@@ -36,7 +32,7 @@ def get_sequencer_run(runs_obj, rname):
             runs.append(i)
     return runs
 
-def get_sequencer_runs(rname,url=oicrurl):
+def get_sequencer_runs(rname, base_pinery_url):
     """
     Gets all of the sequencer runs that match rname from pinery webservice.
     """
@@ -44,9 +40,9 @@ def get_sequencer_runs(rname,url=oicrurl):
     ctx = ssl.create_default_context()
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
-    url=url+"/sequencerruns"
+    pinery_url= base_pinery_url + "/sequencerruns"
     try:
-        rstr = urllib.request.urlopen(url, context=ctx)
+        rstr = urllib.request.urlopen(pinery_url, context=ctx)
         runs=get_sequencer_run(rstr,rname)
     except urllib.error.HTTPError as e:
         print("Pinery HTTP error: %d" % e.code, file=sys.stderr)
@@ -82,7 +78,7 @@ def get_pinery_obj(url):
     return sample
 
 
-def decisions(run, verbose=False, offline=False):
+def decisions(run, base_pinery_url, verbose=False, offline=False):
     succeeded=False
     inprogress=False
     exists=False
@@ -106,7 +102,7 @@ def decisions(run, verbose=False, offline=False):
      if 'samples' in p:
         # exclude failed samples from the count
         pos['num_samples'] = len([x for x in p['samples'] if not (x['status']['state'] == "Failed" or x['data_review'] == "Failed")])
-        pos['exsample_url']=p['samples'][0]['url'].replace("http://localhost:8080",oicrurl)
+        pos['exsample_url']=p['samples'][0]['url'].replace("http://localhost:8080", base_pinery_url)
         pos['num_pending'] = len([x for x in p['samples'] if (x['data_review'] == "Pending")])
         pos['num_notready'] = len([x for x in p['samples'] if (x['status']['name'] == "Not Ready")])
         if pos['num_notready'] > 0:
@@ -200,7 +196,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Searches for and reports the status of sequencer runs in Pinery")
     parser.add_argument("--run", "-r", help="the name of the sequencer run, e.g. 111130_h801_0064_AC043YACXX", required=True)
     parser.add_argument("--json", "-j", help="The sequencer run JSON file to search")
-    parser.add_argument("--url", help=" ".join(["the pinery URL. Default: ",oicrurl]))
+    parser.add_argument("--pinery-url", help="The pinery URL", default="http://pinery.gsi.oicr.on.ca")
     parser.add_argument("--offline", "-o", help="Run in offline mode (don't attempt to contact Pinery). Should be used in combination with --json option.", action="store_true");
     parser.add_argument("--verbose","-v", help="Verbose logging",action="store_true")
     args=parser.parse_args()


### PR DESCRIPTION
If Pinery run-libraries have not been qc'ed, but all related Cardea cases have been, allow the run to be cleaned.

I did apply formatting, the bulk of the relevant change is in 015f6ccae44ef5dc0d4f3908e206f4404970087f